### PR TITLE
Ppc qemu

### DIFF
--- a/plugins/qemu-broker/patches/qemu-patch.diff
+++ b/plugins/qemu-broker/patches/qemu-patch.diff
@@ -28,7 +28,7 @@ index c68bc3ba8a..c499f693f6 100644
      int (*gdb_write_register)(CPUState *cpu, uint8_t *buf, int reg);
  
 diff --git a/include/qemu/qemu-plugin.h b/include/qemu/qemu-plugin.h
-index 97cdfd7761..173c05eeb3 100644
+index 97cdfd7761..db2d03b418 100644
 --- a/include/qemu/qemu-plugin.h
 +++ b/include/qemu/qemu-plugin.h
 @@ -525,6 +525,12 @@ qemu_plugin_register_vcpu_syscall_ret_cb(qemu_plugin_id_t id,
@@ -53,7 +53,7 @@ index 97cdfd7761..173c05eeb3 100644
 +
  #endif /* QEMU_PLUGIN_API_H */
 diff --git a/plugins/api.c b/plugins/api.c
-index b22998cd7c..b6e4a8ca0b 100644
+index b22998cd7c..5945fb9b43 100644
 --- a/plugins/api.c
 +++ b/plugins/api.c
 @@ -46,6 +46,8 @@
@@ -159,7 +159,7 @@ index b22998cd7c..b6e4a8ca0b 100644
 +#endif
 +}
 diff --git a/plugins/qemu-plugins.symbols b/plugins/qemu-plugins.symbols
-index 4bdb381f48..1b12729de7 100644
+index 4bdb381f48..d5ed552763 100644
 --- a/plugins/qemu-plugins.symbols
 +++ b/plugins/qemu-plugins.symbols
 @@ -36,5 +36,9 @@
@@ -313,4 +313,57 @@ index ad99cad0e7..15d0b53918 100644
  
  #ifndef CONFIG_USER_ONLY
      cc->asidx_from_attrs = x86_asidx_from_attrs;
-
+diff --git a/target/ppc/translate_init.c.inc b/target/ppc/translate_init.c.inc
+index c03a7c4f52..9a06c5b12a 100644
+--- a/target/ppc/translate_init.c.inc
++++ b/target/ppc/translate_init.c.inc
+@@ -10664,6 +10664,40 @@ static void ppc_cpu_set_pc(CPUState *cs, vaddr value)
+     cpu->env.nip = value;
+ }
+ 
++static int ppc_cpu_get_register_info(CPUState *cs, const char *reg_name,
++                                     uint8_t *size)
++{
++    // Currently we only implement nip
++    int reg_id = -1;
++    if (!strcmp(reg_name, "nip")) {
++        reg_id = 64;  // Number used for gdb nip register
++#if defined(TARGET_PPC64)
++        *size = 8;
++#else
++        *size = 4;
++#endif
++    }
++
++    return reg_id;
++}
++
++static int ppc_cpu_read_register(CPUState *cs, RegisterValue *dest, int reg_n)
++{
++    PowerPCCPU *cpu = POWERPC_CPU(cs);
++    // Currently we only implement nip
++    if (reg_n != 64) {
++        return -1;
++    }
++
++#if defined(TARGET_PPC64)
++        dest->u64 = cpu->env.nip;
++#else
++        dest->u32 = cpu->env.nip;
++#endif
++
++    return 0;
++}
++
+ static bool ppc_cpu_has_work(CPUState *cs)
+ {
+     PowerPCCPU *cpu = POWERPC_CPU(cs);
+@@ -10916,6 +10950,8 @@ static void ppc_cpu_class_init(ObjectClass *oc, void *data)
+     cc->dump_state = ppc_cpu_dump_state;
+     cc->dump_statistics = ppc_cpu_dump_statistics;
+     cc->set_pc = ppc_cpu_set_pc;
++    cc->get_register_info = ppc_cpu_get_register_info;
++    cc->read_register = ppc_cpu_read_register;
+     cc->gdb_read_register = ppc_cpu_gdb_read_register;
+     cc->gdb_write_register = ppc_cpu_gdb_write_register;
+ #ifndef CONFIG_USER_ONLY


### PR DESCRIPTION
Add PPC support to the QEMU plugin.

Currently this finds the correct bytes to decode as instructions, but fails to decode them.  I don’t *think* it’s an endianness issue but I’m not sure what it is. _**UPDATE**_: see [this comment](https://github.com/immunant/LLVM-MCA-Daemon/pull/1#issuecomment-1370267956) for resolution

I also don’t like directly the qemu-patch.diff file; it seems likely to cause merge conflicts eventually.  For the moment I’m keeping my qemu project in Git and committing the changes there, and then using `git diff -r 0cef06d1 --src-prefix='a/' --dst-prefix='b/'`, but switching to a `git format-patch` based option is probably better (or just keep the qemu changes on github too)

- [ ] ~~Fix endianness issue~~
- [x] Fix crash
- [x] [Add ppc-based targets to build instructions in plugins/qemu-broker/README.md](https://github.com/immunant/LLVM-MCA-Daemon/pull/2)